### PR TITLE
Add eslint rule to require arrow functions in callbacks and refactor

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,6 +12,7 @@
     "semi": ["error", "always"],
     "no-console": "off",
     "indent": ["error", 2],
-    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}]
+    "quotes": ["error", "single", {"avoidEscape": true, "allowTemplateLiterals": true}],
+    "prefer-arrow-callback": "error"
   }
 }

--- a/api.js
+++ b/api.js
@@ -3,7 +3,7 @@
 const botBuilder = require('./lib/bot-builder.js');
 const excuse = require('huh');
 
-module.exports = botBuilder(function (request) {
+module.exports = botBuilder(request =>
   /*
     {
       sender: '',
@@ -12,5 +12,5 @@ module.exports = botBuilder(function (request) {
       type: '' // facebook, slackSlashCommand, slackBot, telegram
     }
   */
-  return Promise.resolve(`Why ${request.text} > ${excuse.get()}`);
-});
+  Promise.resolve(`Why ${request.text} > ${excuse.get()}`)
+);

--- a/spec/bot-builder-spec.js
+++ b/spec/bot-builder-spec.js
@@ -1,16 +1,19 @@
 /*global describe, it, jasmine, expect, beforeEach*/
 var botBuilder = require('../lib/bot-builder');
-describe('BotBuilder', function () {
+describe('BotBuilder', () => {
   var messageHandler, underTest, lambdaContextSpy;
-  beforeEach(function () {
+  
+  beforeEach(() => {
     messageHandler = jasmine.createSpy('messageHandler');
     lambdaContextSpy = jasmine.createSpyObj('lambdaContext', ['done']);
     underTest = botBuilder(messageHandler);
   });
-  it('configures a Claudia Rest API', function () {
+  
+  it('configures a Claudia Rest API', () => {
     expect(underTest.apiConfig().version).toEqual(2);
   });
-  it('sets up a GET route for /', function () {
+
+  it('sets up a GET route for /', () => {
     underTest.router({
       context: {
         path: '/',

--- a/spec/facebook-bot-spec.js
+++ b/spec/facebook-bot-spec.js
@@ -1,7 +1,7 @@
 /*global describe, it, jasmine, expect, beforeEach*/
 var botBuilder = require('../lib/bot-builder'),
   https = require('https');
-describe('Facebook Bot', function () {
+describe('Facebook Bot', () => {
   var messageHandler,
     underTest,
     lambdaContextSpy,
@@ -30,17 +30,20 @@ describe('Facebook Bot', function () {
         }
       ]
     };
-  beforeEach(function () {
+
+  beforeEach(() => {
     messageHandler = jasmine.createSpy('messageHandler');
     lambdaContextSpy = jasmine.createSpyObj('lambdaContext', ['done']);
     underTest = botBuilder(messageHandler);
   });
-  describe('API integration wiring', function () {
-    describe('token verification', function () {
-      it('uses the text/plain content type', function () {
+
+  describe('API integration wiring', () => {
+    describe('token verification', () => {
+      it('uses the text/plain content type', () => {
         expect(underTest.apiConfig().routes.facebook.GET.success.contentType).toEqual('text/plain');
       });
-      it('returns hub challenge if the tokens match', function () {
+
+      it('returns hub challenge if the tokens match', () => {
         underTest.router({
           context: {
             path: '/facebook',
@@ -56,7 +59,8 @@ describe('Facebook Bot', function () {
         }, lambdaContextSpy);
         expect(lambdaContextSpy.done).toHaveBeenCalledWith(null, 'XHCG');
       });
-      it('returns Error challenge if the tokens do not match', function () {
+
+      it('returns Error challenge if the tokens do not match', () => {
         underTest.router({
           context: {
             path: '/facebook',
@@ -73,11 +77,12 @@ describe('Facebook Bot', function () {
         expect(lambdaContextSpy.done).toHaveBeenCalledWith(null, 'Error');
       });
     });
-    describe('message handling', function () {
-      it('sends the response using https to facebook', function (done) {
+
+    describe('message handling', () => {
+      it('sends the response using https to facebook', done => {
 
         var resolveHandler,
-          handlerPromise = new Promise(function (resolve) {
+          handlerPromise = new Promise(resolve => {
             resolveHandler = resolve;
           });
         messageHandler.and.returnValue(Promise.resolve('YES'));
@@ -93,7 +98,7 @@ describe('Facebook Bot', function () {
         }, lambdaContextSpy);
 
         resolveHandler('YES');
-        handlerPromise.then(function () {
+        handlerPromise.then(() => {
           https.request.respond('Thanks!', 200, 'OK');
           expect(https.request).toHaveBeenCalledWith({
             method: 'POST',

--- a/spec/helpers/fake-https-request.js
+++ b/spec/helpers/fake-https-request.js
@@ -1,9 +1,9 @@
 /*global beforeEach, jasmine, afterEach */
 var https = require('https'),
   oldHttpsRequest;
-beforeEach(function () {
+beforeEach(() => {
   var listeners = {};
-  https.request = jasmine.createSpy('httpsRequest').and.callFake(function () {
+  https.request = jasmine.createSpy('httpsRequest').and.callFake(() => {
     var fake = {
       on: function (eventName, listener) {
         listeners[eventName] = listener;
@@ -34,6 +34,6 @@ beforeEach(function () {
     listeners['error'](err);
   };
 });
-afterEach(function () {
+afterEach(() => {
   https.request = oldHttpsRequest;
 });

--- a/spec/support/jasmine-runner.js
+++ b/spec/support/jasmine-runner.js
@@ -4,7 +4,7 @@ var Jasmine = require('jasmine'),
   noop = function () {},
   jrunner = new Jasmine(),
   filter;
-process.argv.slice(2).forEach(function (option) {
+process.argv.slice(2).forEach(option => {
   'use strict';
   if (option === 'full') {
     jrunner.configureDefaultReporter({print: noop});    // remove default reporter logs


### PR DESCRIPTION
ie. use

```js
describe('message handling', () => {
  it('sends the response using https to facebook', done => {
    // ...
  });
});
```

Instead of

```js
describe('message handling', function() {
  it('sends the response using https to facebook', function(done) {
    // ...
  });
});
```